### PR TITLE
Planet collisions quickly deplete shields

### DIFF
--- a/ninjaroot/ninjaships.node.js
+++ b/ninjaroot/ninjaships.node.js
@@ -501,12 +501,12 @@ function _shipObject(options){
       }
     } else if (data.type == 'pnbcollision') {
       // Target hit source (A permanent natural body!)
-      data.target.shieldPowerStatus -= 50;
+      data.target.shieldPowerStatus *= 0.9;
 
       // Kill em if their shield is out
-      if (data.target.shieldPowerStatus <= 0) {
-        data.target.shieldPowerStatus = 0;
-        data.target.triggerBoom();
+      if (data.target.shieldPowerStatus < 1) {
+        data.target.shieldPowerStatus = 1;
+
       }
     }
 


### PR DESCRIPTION
Shields are quickly depleted down to 1 by hitting a planet, but you don't die.  Let's pretend the atmosphere depletes the shields quickly.  This makes travelling through space significantly less frustrating and almost as dangerous.  Testing it locally, it was fun.
