### PR TITLE
Change the planets to a lower number

### DIFF
--- a/ninjaroot/ninjaships.node.js
+++ b/ninjaroot/ninjaships.node.js
@@ -8,7 +8,7 @@ var _powerUps = {}; // All free floating power up orbs are stored with a random 
 var powerUpCount = 20;
 
 var _pnbits = {}; // All permanent natural bodies it the sky stored just like poweups
-var pnbitsCount = 20;
+var pnbitsCount = 5;
 
 var _playArea = 20000; // Size of Square where users will wrap to other side
 var _gameData = require('./ninjanode.gamedata.js');


### PR DESCRIPTION
Changing the number of planets would make the gravitational pull weaker and make it easier to fly around. Having too many planets was a struggle for most players, the lower amount of planets could make it easier to play and fight with others. @MakerBlock ruined the game by adding too many planets. 💩  😃 