### PR TITLE
Pixi renderer parity: Better mobile view, fix render settings, styles, fullscreen!

### DIFF
--- a/public/data/stateModels/AppState.mjs
+++ b/public/data/stateModels/AppState.mjs
@@ -14,7 +14,9 @@ let memoryStore = {};
 
 export const AppState = {
   windowVisible: true,
+  fullscreen: false,
   joined: false,
+  joining: false,
   chatVisible: false,
   socketId: '',
   followShip: '',

--- a/public/index.html
+++ b/public/index.html
@@ -31,25 +31,7 @@
   </head>
   <body>
     <ninja-roster></ninja-roster>
-    <ninja-window id="main-window" head="ninjanode">
-      <h3 class="subhed">
-        A fully open source web browser space ship game, for the hell of it.
-      </h3>
-      <ninja-tabs activeItem="play">
-        <ninja-tab caption="Pick a name and a ship" icon="play" name="play">
-          <ninja-ship-select></ninja-ship-select>
-        </ninja-tab>
-        <ninja-tab caption="Controls" icon="edit" name="controls">
-          <ninja-controls></ninja-controls>
-        </ninja-tab>
-        <ninja-tab caption="Bots" icon="robot" name="bots">
-          <ninja-bots></ninja-bots>
-        </ninja-tab>
-        <ninja-tab caption="Settings" icon="cog" name="settings">
-          <ninja-settings></ninja-settings>
-        </ninja-tab>
-      </ninja-tabs>
-    </ninja-window>
+    <ninja-window-main></ninja-window-main>
     <ninja-chat></ninja-chat>
     <div id="framerate"></div>
     <canvas id="stage" width="400" height="400"></canvas>
@@ -79,7 +61,7 @@
         BotController,
       } from 'modules';
       import { store } from 'hybrids';
-      import { AppState } from 'models';
+      import { AppState, AppStateObserver, UserSettings } from 'models';
 
       // Import and register all web components via side-effects.
       import 'ui';
@@ -107,12 +89,17 @@
         socket,
       });
 
-      // Bind the join event from ship selection.
-      document
-        .getElementsByTagName('ninja-ship-select')[0]
-        .addEventListener('join', ({ detail: { ship: style, name } }) => {
-          socket.join({ style, name });
-        });
+      // AppState joining state change observer, pull data from settings.
+      new AppStateObserver('joining', ({ joining }) => {
+        if (joining) {
+          // Actually attempt to join.
+          const { ship, name } = store.get(UserSettings);
+          socket.join({ style: ship, name });
+
+          // Completed joining request, reset status.
+          store.set(AppState, { joining: false, joined: true });
+        }
+      });
 
       // Setup the Bots
       const bots = [

--- a/public/modules/pixi/PixiRenderer.mjs
+++ b/public/modules/pixi/PixiRenderer.mjs
@@ -69,10 +69,11 @@ export class PixiRenderer {
       // Bind to global settings state changes.
       new UserSettingsObserver('', this.onUserSettingsChange);
 
-      // Set initial mute state from user settings
+      // Set initial states from user settings
       const { mute } = store.get(UserSettings);
       if (mute) sound.muteAll();
 
+      // Mirror layers and viewport to stage.
       this.stage = { ...this.camera.layers, base: this.camera.viewport };
 
       // Add ship getter helper

--- a/public/modules/pixi/PixiRenderer.mjs
+++ b/public/modules/pixi/PixiRenderer.mjs
@@ -43,7 +43,13 @@ export class PixiRenderer {
     const canvas = document.getElementById(options.stageId);
     this.app = new Application();
 
-    const pixiOpts = { canvas, resizeTo: window };
+    const pixiOpts = {
+      canvas,
+      resizeTo: window,
+      antialias: false,
+      autoDensity: true,
+      resolution: 2,
+    };
     this.app.init(pixiOpts).then(async () => {
       // DEBUG: Lock framerate.
       // this.app.ticker.maxFPS = 30;

--- a/public/modules/ui/components/elements/NinjaSlides.mjs
+++ b/public/modules/ui/components/elements/NinjaSlides.mjs
@@ -44,7 +44,7 @@ export const NinjaSlides = {
         margin: 3px;
       }
       .slides {
-        height: ${height}px;
+        height: 100%;
         display: grid;
         width: ${`${items.length * width}${unit}`};
         grid-template-columns: repeat(${items.length}, 1fr);

--- a/public/modules/ui/components/elements/NinjaTabs.mjs
+++ b/public/modules/ui/components/elements/NinjaTabs.mjs
@@ -54,6 +54,7 @@ export const NinjaTabs = {
         float: left;
         margin-right: 1em;
         margin-left: 3px;
+        margin-top: 50px;
       }
       ul {
         list-style: none;

--- a/public/modules/ui/components/features/NinjaSettings.mjs
+++ b/public/modules/ui/components/features/NinjaSettings.mjs
@@ -12,7 +12,14 @@ export const NinjaSettings = {
   settings: () => store.get(UserSettings),
 
   render: ({ settings }) => html`
-    <style></style>
+    <style>
+      div {
+        display: flex;
+        gap: 10px;
+        margin-top: 10px;
+        flex-wrap: wrap;
+      }
+    </style>
     <div>
       <ninja-toggle
         is-on=${settings.freelook}

--- a/public/modules/ui/components/features/NinjaShipInfo.mjs
+++ b/public/modules/ui/components/features/NinjaShipInfo.mjs
@@ -1,0 +1,78 @@
+/**
+ * @file Ninja ship info for the selections creen, takes in shiptype.
+ */
+import { html } from 'hybrids';
+import { shipTypes } from 'data';
+
+export const NinjaShipInfo = {
+  tag: 'ninja-ship-info',
+  type: 'a',
+  config: ({ type }) => shipTypes[type],
+
+  render: ({ config }) => html`
+    <style>
+      :host {
+        color: var(--text-color);
+        overflow-y: scroll;
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+      }
+      div span {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        padding-top: 1em;
+      }
+      h4,
+      h5 {
+        margin: 0;
+        color: var(--button-text-active);
+      }
+
+      @media (max-width: 600px) {
+        :host {
+          display: grid;
+          grid-template-columns: auto;
+        }
+      }
+    </style>
+    <div>
+      <h4>Ship Stats</h4>
+      <h5>${config.name}</h5>
+      <span>
+        <b>Top Speed</b>
+        <ninja-meter
+          ratio=${config.stats.topSpeed}
+          title="${config.topSpeed * 420} kph"
+        ></ninja-meter>
+      </span>
+
+      <span>
+        <b>Acceleration</b>
+        <ninja-meter
+          ratio=${config.stats.accelRate}
+          title="${(config.accelRate * 680).toFixed(2)} cps²"
+        ></ninja-meter>
+      </span>
+    </div>
+
+    <div>
+      <h4>Weapon Stats</h4>
+      <h5>${config.weapons[0].proj.name} (space)</h5>
+      <span>
+        <b>Damage</b>
+        <ninja-meter
+          ratio=${config.stats.primaryWeaponDamage}
+          title="${config.weapons[0].proj.damage} units"
+        ></ninja-meter>
+      </span>
+
+      <span>
+        <b>Speed</b>
+        <ninja-meter
+          ratio=${config.stats.primaryWeaponSpeed}
+          title="${config.weapons[0].proj.speed * 420} kph"
+        ></ninja-meter>
+      </span>
+    </div>
+  `,
+};

--- a/public/modules/ui/components/features/NinjaWindowMain.mjs
+++ b/public/modules/ui/components/features/NinjaWindowMain.mjs
@@ -29,6 +29,7 @@ export const NinjaWindowMain = {
       div.title {
         position: absolute;
         top: -115px;
+        width: 100%;
       }
       h2,
       h3 {

--- a/public/modules/ui/components/features/NinjaWindowMain.mjs
+++ b/public/modules/ui/components/features/NinjaWindowMain.mjs
@@ -1,0 +1,86 @@
+import { html, store } from 'hybrids';
+import { AppState, AppStateObserver } from 'models';
+
+const body = document.querySelector('body');
+
+const fullscreenToggle = (host) => {
+  const fullscreen = !host.fullscreen;
+
+  // State managed by browser event.
+  if (fullscreen) {
+    body.requestFullscreen();
+  } else {
+    if (document.readyState == 'complete') document.exitFullscreen();
+  }
+};
+
+// Catch if the browser took over fullscreen state.
+body.addEventListener('fullscreenchange', () => {
+  // Set state of fullscreen base on document state change.
+  store.set(AppState, { fullscreen: !!document.fullscreenElement });
+});
+
+export const NinjaWindowMain = {
+  tag: 'ninja-window-main',
+  fullscreen: () => store.get(AppState).fullscreen,
+
+  render: ({ fullscreen }) => html`
+    <style>
+      h3.subhed {
+        position: absolute;
+        top: 0;
+        right: 60px;
+        width: 250px;
+        line-height: 17px;
+        font-size: 13px;
+        font-family: var(--head-font);
+        text-transform: lowercase;
+        text-align: right;
+        color: var(--text-color);
+      }
+
+      @media (max-width: 600px) {
+        h3.subhed {
+          font-size: 10px;
+          width: 136px;
+          line-height: 10px;
+          text-align: right;
+          padding-right: 6px;
+          top: 0;
+        }
+      }
+      ninja-button.fullscreen {
+        position: absolute;
+        right: 8px;
+        top: 8px;
+      }
+    </style>
+    <ninja-window id="main-window" head="ninjanode">
+      <h3 class="subhed">
+        A fully open source web browser space ship game, for the hell of it.
+      </h3>
+      <ninja-button
+        class="fullscreen"
+        icon="external-link"
+        active=${fullscreen}
+        title=${fullscreen ? 'Exit Fullscreen' : 'Go Fullscreen'}
+        onclick=${fullscreenToggle}
+        angle=${fullscreen ? 180 : 0}
+      ></ninja-button>
+      <ninja-tabs activeItem="play">
+        <ninja-tab caption="Pick a name and a ship" icon="play" name="play">
+          <ninja-ship-select></ninja-ship-select>
+        </ninja-tab>
+        <ninja-tab caption="Controls" icon="edit" name="controls">
+          <ninja-controls></ninja-controls>
+        </ninja-tab>
+        <ninja-tab caption="Bots" icon="robot" name="bots">
+          <ninja-bots></ninja-bots>
+        </ninja-tab>
+        <ninja-tab caption="Settings" icon="cog" name="settings">
+          <ninja-settings></ninja-settings>
+        </ninja-tab>
+      </ninja-tabs>
+    </ninja-window>
+  `,
+};

--- a/public/modules/ui/components/features/NinjaWindowMain.mjs
+++ b/public/modules/ui/components/features/NinjaWindowMain.mjs
@@ -26,39 +26,61 @@ export const NinjaWindowMain = {
 
   render: ({ fullscreen }) => html`
     <style>
-      h3.subhed {
+      div.title {
         position: absolute;
-        top: 0;
-        right: 60px;
-        width: 250px;
+        top: -115px;
+      }
+      h2,
+      h3 {
+        margin: 0;
+        width: 100%;
+        text-transform: lowercase;
+        text-align: center;
+      }
+      h2 {
+        color: var(--text-color);
+        font-family: var(--head-font);
+        font-weight: 300;
+        font-size: 50px;
+        text-shadow: var(--glow-color) 0px 0px 35px;
+      }
+      h3.subhed {
         line-height: 17px;
         font-size: 13px;
         font-family: var(--head-font);
-        text-transform: lowercase;
-        text-align: right;
         color: var(--text-color);
-      }
-
-      @media (max-width: 600px) {
-        h3.subhed {
-          font-size: 10px;
-          width: 136px;
-          line-height: 10px;
-          text-align: right;
-          padding-right: 6px;
-          top: 0;
-        }
       }
       ninja-button.fullscreen {
         position: absolute;
-        right: 8px;
-        top: 8px;
+        left: 8px;
+        bottom: 8px;
+      }
+
+      ninja-tabs {
+        margin-top: -25px;
+      }
+
+      /* Portrait Phone */
+      @media (max-height: 500px) {
+        div.title {
+          top: 155px;
+          transform: scale(0.7) rotate(-90deg);
+          left: -310px;
+        }
+      }
+
+      /* Landscape Phone */
+      @media (max-width: 600px) {
+        /* TODO */
       }
     </style>
-    <ninja-window id="main-window" head="ninjanode">
-      <h3 class="subhed">
-        A fully open source web browser space ship game, for the hell of it.
-      </h3>
+    <ninja-window id="main-window">
+      <div class="title">
+        <h2>ninjanode</h2>
+        <h3 class="subhed">
+          A fully open source web browser space ship game, for the hell of it.
+        </h3>
+      </div>
       <ninja-button
         class="fullscreen"
         icon="external-link"

--- a/public/modules/ui/components/features/index.mjs
+++ b/public/modules/ui/components/features/index.mjs
@@ -5,3 +5,4 @@ export * from './NinjaShipSelect.mjs';
 export * from './slides/index.mjs';
 export * from './NinjaChat.mjs';
 export * from './NinjaRoster.mjs';
+export * from './NinjaWindowMain.mjs';

--- a/public/modules/ui/components/features/index.mjs
+++ b/public/modules/ui/components/features/index.mjs
@@ -6,3 +6,4 @@ export * from './slides/index.mjs';
 export * from './NinjaChat.mjs';
 export * from './NinjaRoster.mjs';
 export * from './NinjaWindowMain.mjs';
+export * from './NinjaShipInfo.mjs';

--- a/public/modules/ui/components/features/slides/NinjaSlideJoin.mjs
+++ b/public/modules/ui/components/features/slides/NinjaSlideJoin.mjs
@@ -64,302 +64,169 @@ export const NinjaSlideJoin = {
   ship: () => store.get(UserSettings).ship,
   name: () => store.get(UserSettings).name,
   config: ({ ship }) => shipTypes[ship],
-  render: ({ ship, name, config, active }) =>
-    ship
-      ? html`
-          <style>
-            ninja-icon.ship {
-              background-color: ${shipTypes[ship].shield.style};
-              border-radius: 100px;
-              float: right;
-            }
-            h2 {
-              margin: 0;
-              font-family: var(--head-font);
-              text-transform: lowercase;
-              color: var(--text-color);
-            }
-            div.wrapper {
-              display: grid;
-              grid-gap: 8px;
-            }
-            .ship-info {
-              display: grid;
-              height: 170px;
-              box-shadow:
-                -2px 0 0 0 black,
-                2px 0 0 0 black,
-                0 -2px 0 0 black,
-                0 2px 0 0 black;
-              grid-template-columns: 45px auto 76px;
-              grid-template-rows: 41px auto;
-              grid-gap: 10px;
-              padding: 5px;
-              overflow: hidden;
-            }
-            .ship-info .back {
-              grid-area: 1 / 1 / 2 / 2;
-            }
-            .ship-info h2 {
-              grid-area: 1 / 2 / 2 / 3;
-            }
-            .ship-info .ship {
-              grid-area: 1 / 3 / 2 / 4;
-            }
-            .ship-info .breakdown {
-              grid-area: 2 / 1 / 3 / 3;
-            }
-            .ship-info .scroller {
-              grid-area: 2 / 3 / 3 / 4;
-            }
-            footer {
-              display: grid;
-              grid-gap: 10px;
-              grid-template-columns: auto 40px 145px;
-              position: relative;
-            }
-            label {
-              position: absolute;
-              color: gray;
-              bottom: 12px;
-              right: 221px;
-            }
-            input {
-              box-shadow:
-                -3px 0 0 0 var(--border-color),
-                3px 0 0 0 var(--border-color),
-                0 -3px 0 0 var(--border-color),
-                0 3px 0 0 var(--border-color);
-              border: 0;
-              font-family: var(--small-font);
-              font-size: 24px;
-              background-color: var(--text-color);
-              color: var(--text-background);
-              letter-spacing: -3px;
-            }
-            .breakdown {
-              overflow-y: scroll;
-              height: 122px;
-            }
-            table {
-              font-family: var(--small-font);
-              color: var(--text-color);
-              font-size: 11px;
-              line-height: 10px;
-              border-collapse: collapse;
-            }
-            table th {
-              border-bottom: 2px solid var(--border-color);
-            }
-            table td {
-              border-bottom: 1px solid var(--border-color);
-            }
-            table td.spacer {
-              border: 0 none;
-              width: 1.7em;
-            }
-          </style>
-          <div class="wrapper">
-            <div class="ship-info">
-              <ninja-button
-                class="back"
-                size="45"
-                icon="arrow-alt-circle-left"
-                onclick=${back}
-                border-size="0"
-                disabled=${!active}
-              ></ninja-button>
-              <h2>${config.name}</h2>
-              <ninja-icon
-                class="ship"
-                angle="-45"
-                size="72"
-                name=${`ship-${ship}`}
-              ></ninja-icon>
-              <div class="breakdown">
-                <table>
-                  <thead></thead>
-                  <tbody>
-                    <tr>
-                      <th colspan="2">Ship Stats</th>
-                      <td class="spacer"></td>
-                      <th colspan="2">
-                        ${config.weapons[0].proj.name} (space)
-                      </th>
-                      <th>${config.weapons[1].proj.name} (m)</th>
-                    </tr>
-                    <tr>
-                      <td>Top Speed</td>
-                      <td>
-                        <ninja-meter
-                          ratio=${config.stats.topSpeed}
-                          title="${config.topSpeed * 420} kph"
-                        ></ninja-meter>
-                      </td>
-                      <td class="spacer"></td>
-                      <td>Damage</td>
-                      <td>
-                        <ninja-meter
-                          ratio=${config.stats.primaryWeaponDamage}
-                          title="${config.weapons[0].proj.damage} units"
-                        ></ninja-meter>
-                      </td>
-                      <td>
-                        <ninja-meter
-                          ratio=${config.stats.secondaryWeaponDamage}
-                          title="${config.weapons[1].proj.damage} units"
-                        ></ninja-meter>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>Rotation Speed</td>
-                      <td>
-                        <ninja-meter
-                          ratio=${config.stats.rotationSpeed}
-                          title="${config.rotationSpeed} rpm"
-                        ></ninja-meter>
-                      </td>
-                      <td class="spacer"></td>
-                      <td>Speed</td>
-                      <td>
-                        <ninja-meter
-                          ratio=${config.stats.primaryWeaponSpeed}
-                          title="${config.weapons[0].proj.speed} kph"
-                        ></ninja-meter>
-                      </td>
-                      <td>
-                        <ninja-meter
-                          ratio=${config.stats.secondaryWeaponSpeed}
-                          title="${config.weapons[1].proj.speed} kph"
-                        ></ninja-meter>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>Acceleration</td>
-                      <td>
-                        <ninja-meter
-                          ratio=${config.stats.accelRate}
-                          title="${(config.accelRate * 680).toFixed(2)} cps²"
-                        ></ninja-meter>
-                      </td>
-                      <td class="spacer"></td>
-                      <td>Pushback</td>
-                      <td>
-                        <ninja-meter
-                          ratio=${config.stats.primaryWeaponForce}
-                          title="${config.weapons[0].proj.knockBackForce *
-                          42} joules"
-                        ></ninja-meter>
-                      </td>
-                      <td>
-                        <ninja-meter
-                          ratio=${config.stats.secondaryWeaponForce}
-                          title="${config.weapons[1].proj.knockBackForce *
-                          42} joules"
-                        ></ninja-meter>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>Drag</td>
-                      <td>
-                        <ninja-meter
-                          flipped
-                          ratio=${config.stats.drag}
-                          title="${(config.drag * 680).toFixed(2)} cps²"
-                        ></ninja-meter>
-                      </td>
-                      <td class="spacer"></td>
-                      <td>Lifetime</td>
-                      <td>
-                        <ninja-meter
-                          ratio=${config.stats.primaryWeaponLife}
-                          title="${config.weapons[0].proj.life / 1000} secs"
-                        ></ninja-meter>
-                      </td>
-                      <td>
-                        <ninja-meter
-                          ratio=${config.stats.secondaryWeaponLife}
-                          title="${config.weapons[1].proj.life / 1000} secs"
-                        ></ninja-meter>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>Shield (200)</td>
-                      <td>
-                        <ninja-meter
-                          ratio=${config.stats.shieldRate}
-                          title="Regen rate ${config.shield.regenRate * 16} jps"
-                        ></ninja-meter>
-                      </td>
-                      <td class="spacer"></td>
-                      <td>Reload Rate</td>
-                      <td>
-                        <ninja-meter
-                          flipped
-                          ratio=${config.stats.primaryWeaponRate}
-                          title="${config.weapons[0].fireRate / 1000} sec"
-                        ></ninja-meter>
-                      </td>
-                      <td>
-                        <ninja-meter
-                          flipped
-                          ratio=${config.stats.secondaryWeaponRate}
-                          title="${config.weapons[1].fireRate / 1000} secs"
-                        ></ninja-meter>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              <div class="scroller">
-                <ninja-button
-                  solid
-                  border-size="0"
-                  icon="chevron-up"
-                  title="Previous Ship"
-                  onclick=${swapShip(-1)}
-                  disabled=${!active}
-                ></ninja-button>
-                <ninja-button
-                  solid
-                  border-size="0"
-                  icon="chevron-down"
-                  title="Next Ship"
-                  onclick=${swapShip(1)}
-                  disabled=${!active}
-                ></ninja-button>
-              </div>
-            </div>
-            <footer>
-              <label for="name">&lt;&lt; name</label
-              ><input
-                type="text"
-                value=${name}
-                id="name"
-                onchange=${changeName}
-                onkeyup=${catchEnter}
-                size="10"
-                maxlength="20"
-                disabled=${!active}
-                tabindex="0"
-              />
-              <ninja-button
-                icon="face-thinking"
-                title="Random Name"
-                onclick=${randomName}
-                disabled=${!active}
-              ></ninja-button>
-              <ninja-button
-                solid
-                disabled=${!active}
-                class="join"
-                onclick=${join}
-              >
-                Join the Fun
-                <ninja-icon name="chevron-up" size="20" angle="90"></ninja-icon>
-              </ninja-button>
-            </footer>
+  render: ({ ship, name, config, active }) => {
+    if (!ship) return html`<span>Select a valid Ship</span>`;
+    return html`
+      <style>
+        ninja-icon.ship {
+          background-color: ${shipTypes[ship].shield.style};
+          border-radius: 100px;
+          float: right;
+        }
+        h2 {
+          margin: 0;
+          font-family: var(--head-font);
+          text-transform: lowercase;
+          color: var(--text-color);
+        }
+        div.wrapper {
+          display: grid;
+          grid-gap: 8px;
+        }
+        .ship-info {
+          display: grid;
+          box-shadow:
+            -2px 0 0 0 black,
+            2px 0 0 0 black,
+            0 -2px 0 0 black,
+            0 2px 0 0 black;
+          grid-template-columns: 45px auto 76px;
+          grid-template-rows: 41px auto;
+          grid-gap: 10px;
+          padding: 5px;
+          overflow: hidden;
+        }
+        .ship-info .back {
+          grid-area: 1 / 1 / 2 / 2;
+        }
+        .ship-info h2 {
+          grid-area: 1 / 2 / 2 / 3;
+        }
+        .ship-info .ship {
+          grid-area: 1 / 3 / 2 / 4;
+        }
+        .ship-info ninja-ship-info {
+          grid-area: 2 / 1 / 3 / 3;
+        }
+        .ship-info .scroller {
+          grid-area: 2 / 3 / 3 / 4;
+        }
+        footer {
+          display: grid;
+          grid-gap: 10px;
+          grid-template-columns: auto 40px 145px;
+          position: relative;
+          margin: -5px;
+        }
+        label {
+          position: absolute;
+          color: gray;
+          bottom: 12px;
+          right: 221px;
+        }
+        input {
+          box-shadow:
+            -3px 0 0 0 var(--border-color),
+            3px 0 0 0 var(--border-color),
+            0 -3px 0 0 var(--border-color),
+            0 3px 0 0 var(--border-color);
+          border: 0;
+          font-family: var(--small-font);
+          font-size: 24px;
+          background-color: var(--text-color);
+          color: var(--text-background);
+          letter-spacing: -3px;
+        }
+        .breakdown {
+          overflow-y: scroll;
+          height: 122px;
+        }
+
+        @media (max-height: 500px) {
+          div.wrapper {
+            max-height: 200px;
+          }
+        }
+
+        @media (max-width: 530px) {
+          footer {
+            grid-template-columns: auto 40px;
+            grid-template-rows: 40px auto;
+            position: relative;
+          }
+
+          ninja-button.join {
+            grid-area: 2 / 1 / 2 / 3;
+          }
+
+          footer label {
+            bottom: 52px;
+            right: 61px;
+          }
+        }
+      </style>
+      <div class="wrapper">
+        <div class="ship-info">
+          <ninja-button
+            class="back"
+            size="45"
+            icon="arrow-alt-circle-left"
+            onclick=${back}
+            border-size="0"
+            disabled=${!active}
+          ></ninja-button>
+          <h2>${config.name}</h2>
+          <ninja-icon
+            class="ship"
+            angle="-45"
+            size="72"
+            name=${`ship-${ship}`}
+          ></ninja-icon>
+          <ninja-ship-info type=${ship}></ninja-ship-info>
+          <div class="scroller">
+            <ninja-button
+              solid
+              border-size="0"
+              icon="chevron-up"
+              title="Previous Ship"
+              onclick=${swapShip(-1)}
+              disabled=${!active}
+            ></ninja-button>
+            <ninja-button
+              solid
+              border-size="0"
+              icon="chevron-down"
+              title="Next Ship"
+              onclick=${swapShip(1)}
+              disabled=${!active}
+            ></ninja-button>
           </div>
-        `
-      : html`<span>Select a valid Ship</span>`,
+        </div>
+        <footer>
+          <label for="name">&lt;&lt; name</label
+          ><input
+            type="text"
+            value=${name}
+            id="name"
+            onchange=${changeName}
+            onkeyup=${catchEnter}
+            size="10"
+            maxlength="20"
+            disabled=${!active}
+            tabindex="0"
+          />
+          <ninja-button
+            icon="face-thinking"
+            title="Random Name"
+            onclick=${randomName}
+            disabled=${!active}
+          ></ninja-button>
+          <ninja-button solid disabled=${!active} class="join" onclick=${join}>
+            Join the Fun
+            <ninja-icon name="chevron-up" size="20" angle="90"></ninja-icon>
+          </ninja-button>
+        </footer>
+      </div>
+    `;
+  },
 };

--- a/public/modules/ui/components/features/slides/NinjaSlideJoin.mjs
+++ b/public/modules/ui/components/features/slides/NinjaSlideJoin.mjs
@@ -16,7 +16,7 @@ const join = (host) => {
   dispatch(sliderParent, 'join', { detail: settings });
 
   // Set window and joined app states.
-  store.set(AppState, { windowVisible: false, joined: true });
+  store.set(AppState, { windowVisible: false, joining: true });
 
   sound.play('join');
 };

--- a/public/modules/ui/components/widgets/NinjaWindow.mjs
+++ b/public/modules/ui/components/widgets/NinjaWindow.mjs
@@ -28,10 +28,12 @@ export const NinjaWindow = {
         justify-content: center;
         transition: 0.5s ease-in-out;
         min-height: ${!windowVisible ? 0 : '100vh'};
+        max-width: 100%;
+        margin: 1em;
+        max-height: 100%;
       }
       section {
         transition: 0.5s ease-in-out;
-        overflow: hidden;
         background: linear-gradient(
             rgba(18, 16, 16, 0) 50%,
             rgba(0, 0, 0, 0.25) 50%
@@ -46,12 +48,11 @@ export const NinjaWindow = {
         background-size:
           100% 2px,
           3px 100%;
-        max-width: 600px;
-        padding-top: 30px;
+        width: 600px;
         position: relative;
         opacity: ${!windowVisible ? 0 : 1};
         height: ${!windowVisible ? 0 : 'auto'};
-        min-width: 525px;
+        overflow: ${!windowVisible ? 'hidden' : 'visible'};
         z-index: 5;
         box-shadow:
           -3px 0 0 0 var(--border-color),
@@ -63,22 +64,15 @@ export const NinjaWindow = {
 
       @media (max-width: 600px) {
         section {
-          min-width: 380px;
+          /* width: 300px; */
         }
       }
 
-      h2 {
-        color: var(--text-color);
-        font-family: var(--head-font);
-        text-transform: lowercase;
-        padding-left: 0.2em;
-        font-weight: 300;
-        position: absolute;
-        top: -15px;
-        left: 57px;
-        font-size: 30px;
+      @media (max-height: 500px) {
+        section {
+          height: ${!windowVisible ? 0 : 'auto'};
+        }
       }
-
       slot {
         padding: 2em;
         padding: 2em 1em;
@@ -90,6 +84,7 @@ export const NinjaWindow = {
         left: 0;
         top: 0;
         margin: 10px;
+        z-index: 2;
       }
 
       ninja-button#open {

--- a/public/resources/newstyles.css
+++ b/public/resources/newstyles.css
@@ -49,35 +49,7 @@ body {
   z-index: -1;
 }
 
-h2,
-h3,
-h4 {
-  font-family: var(--head-font);
-  text-transform: lowercase;
-  text-align: center;
-  color: var(--text-color);
-}
-
-h3.subhed {
-  position: absolute;
-  top: -9px;
-  right: 0;
-  width: 300px;
-  line-height: 17px;
-  font-size: 15px;
-}
-
-@media (max-width: 600px) {
-  h3.subhed {
-    font-size: 10px;
-    width: 136px;
-    line-height: 10px;
-    text-align: right;
-    padding-right: 6px;
-    top: 0;
-  }
-}
-
+/* Chat overlay position */
 ninja-chat {
   z-index: 1;
   width: 70%;

--- a/public/resources/newstyles.css
+++ b/public/resources/newstyles.css
@@ -40,6 +40,7 @@ body {
   width: 100%;
   height: 100%;
   font-family: var(--body-font);
+  overflow: hidden;
 }
 
 #stage {


### PR DESCRIPTION
## This PR does the following
- Sets the Pixi App rendering resolution correctly which keeps things crispy
- Specifically fixes a number of basic usability issues with the window for mobile
- Moves the window code to its own NinjaWindowMain implementation


<img width="931" alt="Screenshot 2024-12-17 at 3 09 28 PM" src="https://github.com/user-attachments/assets/247dbd05-5814-4c29-98d8-33f189e50c52" />
<img width="454" alt="Screenshot 2024-12-17 at 3 09 03 PM" src="https://github.com/user-attachments/assets/10044c7a-d759-44ef-a464-b3db2c3fc233" />


<img width="912" alt="Screenshot 2024-12-17 at 3 14 13 PM" src="https://github.com/user-attachments/assets/ec294976-bf7a-4ba6-a809-2d78f6f64574" />


### Testing
- [ ] Pull down locally, run with `npm run dev`
- [ ] View the site at http://localhost:4242
- [ ] See the design works at all kinds of sizes, try your phone!